### PR TITLE
support for guzzle http v.7+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": ">=6.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
changed composer requirements since modern projects require guzzle's http v.7+